### PR TITLE
Add Target for UI tests

### DIFF
--- a/DogLand.xcodeproj/project.pbxproj
+++ b/DogLand.xcodeproj/project.pbxproj
@@ -14,11 +14,19 @@
 			remoteGlobalIDString = E675BA352DF24419005A7FC2;
 			remoteInfo = DogLand;
 		};
+		E675BABA2DF3A086005A7FC2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E675BA2E2DF24419005A7FC2 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E675BA352DF24419005A7FC2;
+			remoteInfo = DogLand;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		E675BA362DF24419005A7FC2 /* DogLand.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DogLand.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E675BA8C2DF39743005A7FC2 /* DogLandTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DogLandTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		E675BAB42DF3A086005A7FC2 /* DogLandUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DogLandUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -30,6 +38,11 @@
 		E675BA8D2DF39743005A7FC2 /* DogLandTests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = DogLandTests;
+			sourceTree = "<group>";
+		};
+		E675BAB52DF3A086005A7FC2 /* DogLandUITests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = DogLandUITests;
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -49,6 +62,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		E675BAB12DF3A086005A7FC2 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -57,6 +77,7 @@
 			children = (
 				E675BA382DF24419005A7FC2 /* DogLand */,
 				E675BA8D2DF39743005A7FC2 /* DogLandTests */,
+				E675BAB52DF3A086005A7FC2 /* DogLandUITests */,
 				E675BA372DF24419005A7FC2 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -66,6 +87,7 @@
 			children = (
 				E675BA362DF24419005A7FC2 /* DogLand.app */,
 				E675BA8C2DF39743005A7FC2 /* DogLandTests.xctest */,
+				E675BAB42DF3A086005A7FC2 /* DogLandUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -118,6 +140,29 @@
 			productReference = E675BA8C2DF39743005A7FC2 /* DogLandTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		E675BAB32DF3A086005A7FC2 /* DogLandUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E675BABE2DF3A086005A7FC2 /* Build configuration list for PBXNativeTarget "DogLandUITests" */;
+			buildPhases = (
+				E675BAB02DF3A086005A7FC2 /* Sources */,
+				E675BAB12DF3A086005A7FC2 /* Frameworks */,
+				E675BAB22DF3A086005A7FC2 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				E675BABB2DF3A086005A7FC2 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				E675BAB52DF3A086005A7FC2 /* DogLandUITests */,
+			);
+			name = DogLandUITests;
+			packageProductDependencies = (
+			);
+			productName = DogLandUITests;
+			productReference = E675BAB42DF3A086005A7FC2 /* DogLandUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -132,6 +177,10 @@
 						CreatedOnToolsVersion = 16.4;
 					};
 					E675BA8B2DF39743005A7FC2 = {
+						CreatedOnToolsVersion = 16.4;
+						TestTargetID = E675BA352DF24419005A7FC2;
+					};
+					E675BAB32DF3A086005A7FC2 = {
 						CreatedOnToolsVersion = 16.4;
 						TestTargetID = E675BA352DF24419005A7FC2;
 					};
@@ -153,6 +202,7 @@
 			targets = (
 				E675BA352DF24419005A7FC2 /* DogLand */,
 				E675BA8B2DF39743005A7FC2 /* DogLandTests */,
+				E675BAB32DF3A086005A7FC2 /* DogLandUITests */,
 			);
 		};
 /* End PBXProject section */
@@ -166,6 +216,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		E675BA8A2DF39743005A7FC2 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E675BAB22DF3A086005A7FC2 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -189,6 +246,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		E675BAB02DF3A086005A7FC2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -196,6 +260,11 @@
 			isa = PBXTargetDependency;
 			target = E675BA352DF24419005A7FC2 /* DogLand */;
 			targetProxy = E675BA902DF39743005A7FC2 /* PBXContainerItemProxy */;
+		};
+		E675BABB2DF3A086005A7FC2 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = E675BA352DF24419005A7FC2 /* DogLand */;
+			targetProxy = E675BABA2DF3A086005A7FC2 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -407,6 +476,38 @@
 			};
 			name = Release;
 		};
+		E675BABC2DF3A086005A7FC2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.serrato.DogLandUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = DogLand;
+			};
+			name = Debug;
+		};
+		E675BABD2DF3A086005A7FC2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.serrato.DogLandUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = DogLand;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -433,6 +534,15 @@
 			buildConfigurations = (
 				E675BA932DF39743005A7FC2 /* Debug */,
 				E675BA942DF39743005A7FC2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E675BABE2DF3A086005A7FC2 /* Build configuration list for PBXNativeTarget "DogLandUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E675BABC2DF3A086005A7FC2 /* Debug */,
+				E675BABD2DF3A086005A7FC2 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/DogLandUITests/DogLandUITests.swift
+++ b/DogLandUITests/DogLandUITests.swift
@@ -1,0 +1,41 @@
+//
+//  DogLandUITests.swift
+//  DogLandUITests
+//
+//  Created by Jose Miguel Serrato Moreno on 06/06/25.
+//
+
+import XCTest
+
+final class DogLandUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    @MainActor
+    func testExample() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    @MainActor
+    func testLaunchPerformance() throws {
+        // This measures how long it takes to launch your application.
+        measure(metrics: [XCTApplicationLaunchMetric()]) {
+            XCUIApplication().launch()
+        }
+    }
+}

--- a/DogLandUITests/DogLandUITestsLaunchTests.swift
+++ b/DogLandUITests/DogLandUITestsLaunchTests.swift
@@ -1,0 +1,33 @@
+//
+//  DogLandUITestsLaunchTests.swift
+//  DogLandUITests
+//
+//  Created by Jose Miguel Serrato Moreno on 06/06/25.
+//
+
+import XCTest
+
+final class DogLandUITestsLaunchTests: XCTestCase {
+
+    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+        true
+    }
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    @MainActor
+    func testLaunch() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Insert steps here to perform after app launch but before taking a screenshot,
+        // such as logging into a test account or navigating somewhere in the app
+
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Launch Screen"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}


### PR DESCRIPTION
## 📲 What’s this PR about?

Add new target XCUITest for UI/Automation tests

## 🔗 Related Tasks / Issues

Closes NA  
Related to: NA

## 🧾 Summary of Changes

- [x] Created/Updated SwiftUI view `XView`
- [x] Added network layer for `EndpointY`
- [x] Refactored `ViewModelZ` to use Combine
- [x] Updated unit tests for `FeatureA`

## 🧪 Testing Performed

- [x] Built successfully in Xcode
- [x] Ran unit tests in Xcode (`⌘+U`)
- [x] Verified on device/simulator (iPhone XX)
- [x] UI tested (if visual changes)

### Notes:

## 🧰 Tools & Frameworks

- [ ] SwiftUI
- [ ] UIKit
- [ ] Combine
- [ ] CoreData
- [ ] Swift Concurrency (async/await)
- [ ] Fastlane
- [ ] GitHub Actions
- [x] XCUITest

## 🧠 Checklist

- [x] Follows architecture (e.g., MVVM, VIPER, Clean)
- [x] No force unwraps (`!`)
- [x] No hardcoded strings/colors
- [x] Localized any new strings
- [x] Added/updated documentation or comments
- [x] PR has a clear, descriptive title
- [ ] Verified code on dark and light mode (UI change only)

---

